### PR TITLE
Adding support for Mockito spy  (#20) …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,13 @@
       <version>1.7.25</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.23.4</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- test dependencies -->
 
     <dependency>

--- a/src/main/java/io/dinject/BootContext.java
+++ b/src/main/java/io/dinject/BootContext.java
@@ -3,7 +3,7 @@ package io.dinject;
 import io.dinject.core.BeanContextFactory;
 import io.dinject.core.Builder;
 import io.dinject.core.BuilderFactory;
-import io.dinject.core.SpyConsumer;
+import io.dinject.core.EnrichBean;
 import io.dinject.core.SuppliedBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +56,7 @@ public class BootContext {
 
   private final List<SuppliedBean> suppliedBeans = new ArrayList<>();
 
-  private final List<SpyConsumer> spyConsumers = new ArrayList<>();
+  private final List<EnrichBean> enrichBeans = new ArrayList<>();
 
   private final Set<String> includeModules = new LinkedHashSet<>();
 
@@ -227,7 +227,7 @@ public class BootContext {
    * Use a mockito spy when injecting this bean type.
    */
   public <D> BootContext withSpy(Class<D> type) {
-    spyConsumers.add(new SpyConsumer<>(type, null));
+    enrichBeans.add(new EnrichBean<>(type, null));
     return this;
   }
 
@@ -235,7 +235,7 @@ public class BootContext {
    * Use a mockito spy when injecting this bean type additionally running setup on the spy instance.
    */
   public <D> BootContext withSpy(Class<D> type, Consumer<D> consumer) {
-    spyConsumers.add(new SpyConsumer<>(type, consumer));
+    enrichBeans.add(new EnrichBean<>(type, consumer));
     return this;
   }
 
@@ -251,7 +251,7 @@ public class BootContext {
     Set<String> moduleNames = factoryOrder.orderFactories();
     log.debug("building context with modules {}", moduleNames);
 
-    Builder rootBuilder = BuilderFactory.newRootBuilder(suppliedBeans, spyConsumers);
+    Builder rootBuilder = BuilderFactory.newRootBuilder(suppliedBeans, enrichBeans);
 
     for (BeanContextFactory factory : factoryOrder.factories()) {
       rootBuilder.addChild(factory.createContext(rootBuilder));

--- a/src/main/java/io/dinject/core/Builder.java
+++ b/src/main/java/io/dinject/core/Builder.java
@@ -125,4 +125,12 @@ public interface Builder {
    */
   BeanContext build();
 
+  /**
+   * Return a spy enhanced bean for registration into the context.
+   *
+   * @param bean  The bean with dependencies injected
+   * @param types The types this bean registers for
+   * @return Either the bean or the spy enhanced bean to register into the context.
+   */
+  Object spy(Object bean, Class<?>[] types);
 }

--- a/src/main/java/io/dinject/core/Builder.java
+++ b/src/main/java/io/dinject/core/Builder.java
@@ -126,11 +126,12 @@ public interface Builder {
   BeanContext build();
 
   /**
-   * Return a spy enhanced bean for registration into the context.
+   * Return a potentially enriched bean for registration into the context.
+   * Typically for use with mockito spy.
    *
    * @param bean  The bean with dependencies injected
    * @param types The types this bean registers for
-   * @return Either the bean or the spy enhanced bean to register into the context.
+   * @return Either the bean or the enriched bean to register into the context.
    */
-  Object spy(Object bean, Class<?>[] types);
+  Object enrich(Object bean, Class<?>[] types);
 }

--- a/src/main/java/io/dinject/core/BuilderFactory.java
+++ b/src/main/java/io/dinject/core/BuilderFactory.java
@@ -13,9 +13,10 @@ public class BuilderFactory {
    * Create the root level Builder.
    *
    * @param suppliedBeans The list of beans (typically test doubles) supplied when building the context.
+   * @param spyConsumers The list of classes we want to have with mockito spy enhancement
    */
-  public static Builder newRootBuilder(List<SuppliedBean> suppliedBeans) {
-    return new DBuilder(suppliedBeans);
+  public static Builder newRootBuilder(List<SuppliedBean> suppliedBeans, List<SpyConsumer> spyConsumers) {
+    return new DBuilder(suppliedBeans, spyConsumers);
   }
 
   /**

--- a/src/main/java/io/dinject/core/BuilderFactory.java
+++ b/src/main/java/io/dinject/core/BuilderFactory.java
@@ -13,10 +13,15 @@ public class BuilderFactory {
    * Create the root level Builder.
    *
    * @param suppliedBeans The list of beans (typically test doubles) supplied when building the context.
-   * @param spyConsumers The list of classes we want to have with mockito spy enhancement
+   * @param enrichBeans   The list of classes we want to have with mockito spy enhancement
    */
-  public static Builder newRootBuilder(List<SuppliedBean> suppliedBeans, List<SpyConsumer> spyConsumers) {
-    return new DBuilder(suppliedBeans, spyConsumers);
+  public static Builder newRootBuilder(List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans) {
+
+    if (suppliedBeans.isEmpty() && enrichBeans.isEmpty()) {
+      // simple case, no mocks or spies
+      return new DBuilder();
+    }
+    return new DBuilderExtn(suppliedBeans, enrichBeans);
   }
 
   /**

--- a/src/main/java/io/dinject/core/DBuilderExtn.java
+++ b/src/main/java/io/dinject/core/DBuilderExtn.java
@@ -1,0 +1,72 @@
+package io.dinject.core;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Extended builder that supports supplied beans (mocks) and enriching beans (spy).
+ */
+public class DBuilderExtn extends DBuilder {
+
+  private final Map<Class<?>, EnrichBean> enrichMap = new HashMap<>();
+
+  private final boolean hasSuppliedBeans;
+
+  DBuilderExtn(List<SuppliedBean> suppliedBeans, List<EnrichBean> enrichBeans) {
+    super();
+    this.hasSuppliedBeans = (suppliedBeans != null && !suppliedBeans.isEmpty());
+    if (hasSuppliedBeans) {
+      beanMap.add(suppliedBeans);
+    }
+    if (enrichBeans != null && !enrichBeans.isEmpty()) {
+      for (EnrichBean spy : enrichBeans) {
+        enrichMap.put(spy.getType(), spy);
+      }
+    }
+  }
+
+  /**
+   * Checking for supplied beans (mocks).
+   */
+  @Override
+  public boolean isAddBeanFor(Class<?> addForType, Class<?> injectTarget) {
+    if (hasSuppliedBeans) {
+      return !beanMap.isSupplied(addForType.getName());
+    }
+    return true;
+  }
+
+  /**
+   * Register beans with potential enhancement (spy).
+   */
+  @Override
+  public void register(Object bean, String name, Class<?>... types) {
+    if (parent != null) {
+      throw new IllegalStateException("no");
+    }
+    // this is the top level builder (parent always null)
+    bean = enrich(bean, types);
+    beanMap.register(bean, name, types);
+  }
+
+  /**
+   * Potentially enrich the bean prior to registering with context.
+   */
+  @SuppressWarnings("unchecked")
+  @Override
+  public Object enrich(Object bean, Class<?>[] types) {
+    EnrichBean enrich = enrichMap.get(typeOf(bean, types));
+    return enrich != null ? enrich.enrich(bean) : bean;
+  }
+
+  /**
+   * Return the type to lookup for enrichment.
+   */
+  private Class<?> typeOf(Object bean, Class<?>... types) {
+    if (types.length > 0) {
+      return types[0];
+    }
+    return bean.getClass();
+  }
+}

--- a/src/main/java/io/dinject/core/EnrichBean.java
+++ b/src/main/java/io/dinject/core/EnrichBean.java
@@ -7,13 +7,13 @@ import java.util.function.Consumer;
 /**
  * Holds Spy setup consumers for dependency injection using Mockito Spy.
  */
-public class SpyConsumer<B> {
+public class EnrichBean<B> {
 
   private final Class<B> type;
 
   private final Consumer<B> consumer;
 
-  public SpyConsumer(Class<B> type, Consumer<B> consumer) {
+  public EnrichBean(Class<B> type, Consumer<B> consumer) {
     this.type = type;
     this.consumer = consumer;
   }
@@ -28,8 +28,9 @@ public class SpyConsumer<B> {
   /**
    * Return the spy enhanced bean instance to use.
    */
-  public B spy(B bean) {
+  public B enrich(B bean) {
 
+    // should extract a SPI for this. Only enrichment is Mockito spy at this point.
     B spy = Mockito.spy(bean);
     if (consumer != null) {
       consumer.accept(spy);

--- a/src/main/java/io/dinject/core/SpyConsumer.java
+++ b/src/main/java/io/dinject/core/SpyConsumer.java
@@ -1,0 +1,39 @@
+package io.dinject.core;
+
+import org.mockito.Mockito;
+
+import java.util.function.Consumer;
+
+/**
+ * Holds Spy setup consumers for dependency injection using Mockito Spy.
+ */
+public class SpyConsumer<B> {
+
+  private final Class<B> type;
+
+  private final Consumer<B> consumer;
+
+  public SpyConsumer(Class<B> type, Consumer<B> consumer) {
+    this.type = type;
+    this.consumer = consumer;
+  }
+
+  /**
+   * Return the dependency injection target type.
+   */
+  public Class<B> getType() {
+    return type;
+  }
+
+  /**
+   * Return the spy enhanced bean instance to use.
+   */
+  public B spy(B bean) {
+
+    B spy = Mockito.spy(bean);
+    if (consumer != null) {
+      consumer.accept(spy);
+    }
+    return spy;
+  }
+}

--- a/src/main/java/io/dinject/core/SuppliedBean.java
+++ b/src/main/java/io/dinject/core/SuppliedBean.java
@@ -1,5 +1,9 @@
 package io.dinject.core;
 
+import org.mockito.Mockito;
+
+import java.util.function.Consumer;
+
 /**
  * Holds beans supplied to the dependency injection.
  * <p>
@@ -8,31 +12,47 @@ package io.dinject.core;
  * would normally be injected.
  * </p>
  */
-public class SuppliedBean {
+public class SuppliedBean<B> {
 
-  private final Class<?> type;
+  private final Class<B> type;
 
-  private final Object bean;
+  private final Consumer<B> consumer;
+
+  private B bean;
 
   /**
    * Create with a given target type and bean instance.
    */
-  public SuppliedBean(Class<?> type, Object bean) {
+  public SuppliedBean(Class<B> type, B bean) {
+    this(type, bean, null);
+  }
+
+  /**
+   * Create with a consumer to setup the mock.
+   */
+  public SuppliedBean(Class<B> type, B bean, Consumer<B> consumer) {
     this.type = type;
     this.bean = bean;
+    this.consumer = consumer;
   }
 
   /**
    * Return the dependency injection target type.
    */
-  public Class<?> getType() {
+  public Class<B> getType() {
     return type;
   }
 
   /**
    * Return the bean instance to use (often a test double or mock).
    */
-  public Object getBean() {
+  public B getBean() {
+    if (bean == null) {
+      bean = Mockito.mock(type);
+    }
+    if (consumer != null) {
+      consumer.accept(bean);
+    }
     return bean;
   }
 }

--- a/src/main/java/io/dinject/core/SuppliedBean.java
+++ b/src/main/java/io/dinject/core/SuppliedBean.java
@@ -48,6 +48,7 @@ public class SuppliedBean<B> {
    */
   public B getBean() {
     if (bean == null) {
+      // should extract a SPI for this
       bean = Mockito.mock(type);
     }
     if (consumer != null) {

--- a/src/test/java/org/example/coffee/BootContextAddTest.java
+++ b/src/test/java/org/example/coffee/BootContextAddTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 
 public class BootContextAddTest {
 
@@ -76,6 +77,10 @@ public class BootContextAddTest {
 
       CoffeeMaker coffeeMaker = context.getBean(CoffeeMaker.class);
       assertThat(coffeeMaker).isNotNull();
+      coffeeMaker.makeIt();
+
+      verify(pump).pumpSteam();
+      verify(pump).pumpWater();
     }
   }
 

--- a/src/test/java/org/example/coffee/BootContext_mockitoSpyTest.java
+++ b/src/test/java/org/example/coffee/BootContext_mockitoSpyTest.java
@@ -1,0 +1,110 @@
+package org.example.coffee;
+
+import io.dinject.BeanContext;
+import io.dinject.BootContext;
+import org.example.coffee.grind.Grinder;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+public class BootContext_mockitoSpyTest {
+
+  @Test
+  public void withMockitoSpy_noSetup_expect_spyUsed() {
+
+    try (BeanContext context = new BootContext()
+      .withSpy(Pump.class)
+      .load()) {
+
+      CoffeeMaker coffeeMaker = context.getBean(CoffeeMaker.class);
+      assertThat(coffeeMaker).isNotNull();
+      coffeeMaker.makeIt();
+
+      Pump pump = context.getBean(Pump.class);
+      verify(pump).pumpWater();
+    }
+  }
+
+  @Test
+  public void withMockitoSpy_postLoadSetup_expect_spyUsed() {
+
+    try (BeanContext context = new BootContext()
+      .withSpy(Pump.class)
+      .load()) {
+
+      // setup after load()
+      Pump pump = context.getBean(Pump.class);
+      doNothing().when(pump).pumpWater();
+
+      CoffeeMaker coffeeMaker = context.getBean(CoffeeMaker.class);
+      assertThat(coffeeMaker).isNotNull();
+      coffeeMaker.makeIt();
+
+      verify(pump).pumpWater();
+    }
+  }
+
+  @Test
+  public void withMockitoSpy_expect_spyUsed() {
+
+    try (BeanContext context = new BootContext()
+      .withSpy(Pump.class, pump -> {
+        // setup the spy
+        doNothing().when(pump).pumpWater();
+      })
+      .load()) {
+
+      Pump pump = context.getBean(Pump.class);
+
+      CoffeeMaker coffeeMaker = context.getBean(CoffeeMaker.class);
+      assertThat(coffeeMaker).isNotNull();
+      coffeeMaker.makeIt();
+
+      verify(pump).pumpWater();
+    }
+  }
+
+  @Test
+  public void withMockitoMock_expect_mockUsed() {
+
+    AtomicReference<Pump> mock = new AtomicReference<>();
+
+    try (BeanContext context = new BootContext()
+      .withMock(Grinder.class)
+      .withMock(Pump.class, pump -> {
+        // do something interesting to setup the mock
+        mock.set(pump);
+      })
+      .load()) {
+
+      Pump pump = context.getBean(Pump.class);
+      assertThat(pump).isSameAs(mock.get());
+
+      CoffeeMaker coffeeMaker = context.getBean(CoffeeMaker.class);
+      assertThat(coffeeMaker).isNotNull();
+    }
+  }
+
+  /**
+   * Our test double that we want to wire.
+   */
+  class TDPump implements Pump {
+
+    int water;
+    int steam;
+
+    @Override
+    public void pumpWater() {
+      water++;
+    }
+
+    @Override
+    public void pumpSteam() {
+      steam++;
+    }
+  }
+}

--- a/src/test/java/org/example/coffee/CoffeeMaker.java
+++ b/src/test/java/org/example/coffee/CoffeeMaker.java
@@ -1,6 +1,5 @@
 package org.example.coffee;
 
-import io.dinject.ContextModule;
 import org.example.coffee.grind.Grinder;
 
 import javax.inject.Singleton;
@@ -20,7 +19,7 @@ public class CoffeeMaker {
 
   public String makeIt() {
     System.out.println("making it ...");
-    grinder.grindBeans();
+    System.out.println("grinder:" + grinder.grindBeans());
     pump.pumpWater();
     pump.pumpSteam();
     System.out.println("Done");


### PR DESCRIPTION
This is enhancement of the instance with dependencies injected and then registering/using that enhanced instance.

Need to consider using an SPI for the Mockito.mock() and Mockito.spy() rather than the direct calls.